### PR TITLE
feat: Implement .gitattributes parsing to exclude files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyQt6
 pyperclip
 gitignore-parser
+fnmatch


### PR DESCRIPTION
This introduces functionality to read and process the project's root .gitattributes file. The script can now automatically exclude files and directories marked as generated or vendored, which improves the quality and relevance of the context provided to an LLM.

Key changes include:

- A new `get_gitattributes_matcher` function has been created. It parses the `.gitattributes` file and returns a matcher function to check file paths against its rules.

- Support for the following Linguist attributes has been implemented:
  - Positive attributes: `linguist-generated`, `linguist-generated=true`, `linguist-vendored`.
  - Negating attributes: `-linguist-generated`, `linguist-generated=false` to create exceptions.

- The parsing logic respects rule precedence: the last matching rule for a given path overrides any previous ones, mirroring Git's native behavior.

- The new matcher is integrated into both the main file collection logic (`create_llm_context`) and the project tree generation (`get_project_structure`) to ensure consistent output.